### PR TITLE
Components equivalent to Promise all/race

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,3 @@ to one out port versus another (or not at all).
 
 Feel free to contribute new components and graphs! I'll try to
 incorporate as soon as time allows.
-
-## Usage
-
-### flow/BufferUntil
-
-Buffer all IPs until we're ready, after which point, everything is passed
-through.
-
-* In-port IN: the IPs to receive and cache
-* In-port READY: send any IP to signal that we're ready
-* Out-port OUT: out comes the IPs

--- a/components/All.coffee
+++ b/components/All.coffee
@@ -65,6 +65,8 @@ exports.getComponent = ->
     results = c.pending[input.scope].results
     indexesWithStreams.forEach (idx) ->
       stream = input.getStream(['in', idx]).filter (ip) -> ip.type is 'data'
+      # If this connection already sent, disregard the new stream
+      return if results[idx]
       # Add to results
       results[idx] = [] unless results[idx]
       results[idx] = results[idx].concat stream

--- a/components/All.coffee
+++ b/components/All.coffee
@@ -1,0 +1,90 @@
+noflo = require 'noflo'
+
+prepareScope = ->
+  data =
+    results: {}
+    resolved: false
+    rejected: false
+  return data
+
+exports.getComponent = ->
+  c = new noflo.Component
+  c.description = 'Like Promise.all, wait for result from all connected inputs
+   and send them or an error out'
+  c.icon = 'compress'
+  c.inPorts.add 'in',
+    datatype: 'all'
+    addressable: true
+  c.inPorts.add 'error',
+    datatype: 'object'
+  c.outPorts.add 'out',
+    datatype: 'array'
+  c.outPorts.add 'error',
+    datatype: 'object'
+  c.pending = {}
+  c.tearDown = (callback) ->
+    c.pending = {}
+    do callback
+  c.forwardBrackets = {}
+  c.process (input, output) ->
+    if input.hasData 'error'
+      # There is a failure in this scope, reject it
+      err = input.getData 'error'
+      unless c.pending[input.scope]
+        c.pending[input.scope] = prepareScope()
+      if c.pending[input.scope].rejected or c.pending[input.scope].resolved
+        # This scope was already resolved
+        output.done()
+        return
+      # Mark scope as rejected
+      c.pending[input.scope].rejected = true
+      # Drop any results since something failed
+      delete c.pending[input.scope].results
+      output.sendDone
+        error: err
+      return
+
+    # See if we have any input results
+    indexesWithStreams = input.attached('in').filter (idx) ->
+      input.hasStream ['in', idx]
+    return unless indexesWithStreams.length
+
+    unless c.pending[input.scope]
+      c.pending[input.scope] = prepareScope()
+
+    # Check if the execution was already resolved
+    if c.pending[input.scope].rejected or c.pending[input.scope].resolved
+      indexesWithStreams.forEach (idx) ->
+        # Drop all packets that arrive after resolution
+        stream = input.getStream ['in', idx]
+        ip.drop() for ip in stream
+      output.done()
+      return
+
+    # Read results
+    results = c.pending[input.scope].results
+    indexesWithStreams.forEach (idx) ->
+      stream = input.getStream(['in', idx]).filter (ip) -> ip.type is 'data'
+      # Add to results
+      results[idx] = [] unless results[idx]
+      results[idx] = results[idx].concat stream
+
+    # Check if we have all results
+    for idx in input.attached('in')
+      continue if results[idx]?.length
+      # Still waiting
+      output.done()
+      return
+
+    # Mark as resolved
+    c.pending[input.scope].resolved = true
+    # Send data
+    resultData = input.attached('in').map (idx) ->
+      data = results[idx].map (ip) -> ip.data
+      if data.length is 1
+        return data[0]
+      return data
+    output.sendDone
+      out: resultData
+    # Clean packets
+    delete c.pending[input.scope].results

--- a/components/Race.coffee
+++ b/components/Race.coffee
@@ -1,0 +1,72 @@
+noflo = require 'noflo'
+
+prepareScope = ->
+  data =
+    resolved: false
+    rejected: false
+  return data
+
+exports.getComponent = ->
+  c = new noflo.Component
+  c.description = 'Like Promise.all, wait for result from all connected inputs
+   and send them or an error out'
+  c.icon = 'compress'
+  c.inPorts.add 'in',
+    datatype: 'all'
+    addressable: true
+  c.inPorts.add 'error',
+    datatype: 'object'
+  c.outPorts.add 'out',
+    datatype: 'array'
+  c.outPorts.add 'error',
+    datatype: 'object'
+  c.pending = {}
+  c.tearDown = (callback) ->
+    c.pending = {}
+    do callback
+  c.forwardBrackets = {}
+  c.process (input, output) ->
+    if input.hasData 'error'
+      # There is a failure in this scope, reject it
+      err = input.getData 'error'
+      unless c.pending[input.scope]
+        c.pending[input.scope] = prepareScope()
+      if c.pending[input.scope].rejected or c.pending[input.scope].resolved
+        # This scope was already resolved
+        output.done()
+        return
+      # Mark scope as rejected
+      c.pending[input.scope].rejected = true
+      output.sendDone
+        error: err
+      return
+
+    # See if we have any input results
+    indexesWithStreams = input.attached('in').filter (idx) ->
+      input.hasStream ['in', idx]
+    return unless indexesWithStreams.length
+
+    unless c.pending[input.scope]
+      c.pending[input.scope] = prepareScope()
+
+    # Check if the execution was already resolved
+    if c.pending[input.scope].rejected or c.pending[input.scope].resolved
+      indexesWithStreams.forEach (idx) ->
+        # Drop all packets that arrive after resolution
+        stream = input.getStream ['in', idx]
+        ip.drop() for ip in stream
+      output.done()
+      return
+
+    # Read results
+    results = input.getStream(['in', indexesWithStreams[0]]).filter (ip) ->
+      ip.type is 'data'
+
+    # Mark as resolved
+    c.pending[input.scope].resolved = true
+    # Send data
+    data = results.map (ip) -> ip.data
+    if data.length is 1
+      data = data[0]
+    output.sendDone
+      out: data

--- a/spec/All.coffee
+++ b/spec/All.coffee
@@ -56,7 +56,7 @@ describe 'All component', ->
         done()
       ins[1].send 123
       ins[0].send 'hello world'
-    it 'should support multiple packets in input data', (done) ->
+    it 'should support a stream in input data', (done) ->
       errOut.on 'data', done
       out.on 'data', (data) ->
         chai.expect(data).to.eql [
@@ -64,12 +64,30 @@ describe 'All component', ->
           [123, 456]
         ]
         done()
+      ins[1].send new noflo.IP 'openBracket', null,
+        scope: 0
       ins[1].send new noflo.IP 'data', 123,
         scope: 0
       ins[1].send new noflo.IP 'data', 456,
         scope: 0
+      ins[1].send new noflo.IP 'closeBracket', null,
+        scope: 0
       ins[0].send new noflo.IP 'data', 'hello world',
         scope: 0
+    it 'should only use first stream from input data', (done) ->
+      errOut.on 'data', done
+      out.on 'data', (data) ->
+        chai.expect(data).to.eql [
+          'hello world'
+          123
+        ]
+        done()
+      ins[1].send new noflo.IP 'data', 123,
+        scope: 3
+      ins[1].send new noflo.IP 'data', 456,
+        scope: 3
+      ins[0].send new noflo.IP 'data', 'hello world',
+        scope: 3
     it 'should send results by scope', (done) ->
       expected = [
         scope: 2

--- a/spec/All.coffee
+++ b/spec/All.coffee
@@ -1,0 +1,159 @@
+noflo = require 'noflo'
+
+unless noflo.isBrowser()
+  chai = require 'chai'
+  path = require 'path'
+  baseDir = path.resolve __dirname, '../'
+else
+  baseDir = 'noflo-flow'
+
+describe 'All component', ->
+  c = null
+  ins = []
+  errIn = null
+  out = null
+  errOut = null
+
+  before (done) ->
+    @timeout 4000
+    loader = new noflo.ComponentLoader baseDir
+    loader.load 'flow/All', (err, instance) ->
+      return done err if err
+      c = instance
+      ins.push noflo.internalSocket.createSocket()
+      ins.push noflo.internalSocket.createSocket()
+      ins.push noflo.internalSocket.createSocket()
+      ins.push noflo.internalSocket.createSocket()
+      ins.push noflo.internalSocket.createSocket()
+      errIn = noflo.internalSocket.createSocket()
+      instance.inPorts.error.attach errIn
+      done()
+  beforeEach ->
+    out = noflo.internalSocket.createSocket()
+    c.outPorts.out.attach out
+    errOut = noflo.internalSocket.createSocket()
+    c.outPorts.error.attach errOut
+  afterEach ->
+    c.outPorts.out.detach out
+    out = null
+    c.outPorts.error.detach errOut
+    errOut = null
+  describe 'receiving results for two inbound connections', ->
+    before ->
+      c.inPorts.in.attach ins[0]
+      c.inPorts.in.attach ins[1]
+    after (done) ->
+      c.inPorts.in.detach ins[1]
+      c.inPorts.in.detach ins[0]
+      c.shutdown done
+    it 'should send the results out', (done) ->
+      errOut.on 'data', done
+      out.on 'data', (data) ->
+        chai.expect(data).to.eql [
+          'hello world'
+          123
+        ]
+        done()
+      ins[1].send 123
+      ins[0].send 'hello world'
+    it 'should support multiple packets in input data', (done) ->
+      errOut.on 'data', done
+      out.on 'data', (data) ->
+        chai.expect(data).to.eql [
+          'hello world'
+          [123, 456]
+        ]
+        done()
+      ins[1].send new noflo.IP 'data', 123,
+        scope: 0
+      ins[1].send new noflo.IP 'data', 456,
+        scope: 0
+      ins[0].send new noflo.IP 'data', 'hello world',
+        scope: 0
+    it 'should send results by scope', (done) ->
+      expected = [
+        scope: 2
+        data: ['hello world', 123]
+      ,
+        scope: 1
+        data: [5542, 'foo bar']
+      ]
+      errOut.on 'data', done
+      out.on 'ip', (ip) ->
+        return unless ip.type is 'data'
+        expect = expected.shift()
+        chai.expect(ip.scope).to.equal expect.scope
+        chai.expect(ip.data).to.eql expect.data
+        return if expected.length
+        done()
+      ins[0].send new noflo.IP 'data', 5542,
+        scope: 1
+      ins[1].send new noflo.IP 'data', 123,
+        scope: 2
+      ins[0].send new noflo.IP 'data', 'hello world',
+        scope: 2
+      ins[1].send new noflo.IP 'data', 'foo bar',
+        scope: 1
+  describe 'receiving result and error for two inbound connections', ->
+    before ->
+      c.inPorts.in.attach ins[0]
+      c.inPorts.in.attach ins[1]
+    after (done) ->
+      c.inPorts.in.detach ins[1]
+      c.inPorts.in.detach ins[0]
+      c.shutdown done
+    it 'should send the error out and no results', (done) ->
+      errOut.on 'data', (err) ->
+        chai.expect(err).to.be.an 'error'
+        chai.expect(err.message).to.equal 'Error on first'
+        done()
+      out.on 'data', (data) ->
+        done new Error 'Unexpected data received'
+      ins[1].send 123
+      errIn.send new Error "Error on first"
+    it 'should send the error out and no results', (done) ->
+      errOut.on 'ip', (ip) ->
+        return unless ip.type is 'data'
+        chai.expect(ip.data).to.be.an 'error'
+        chai.expect(ip.data.message).to.equal 'Error on scope'
+        chai.expect(ip.scope).to.equal 0
+        done()
+      out.on 'data', (data) ->
+        done new Error 'Unexpected data received'
+      ins[1].send new noflo.IP 'data', 123,
+        scope: 0
+      ins[1].send new noflo.IP 'data', 456,
+        scope: 0
+      errIn.send new noflo.IP 'data', new Error('Error on scope'),
+        scope: 0
+    it 'should send results by scope', (done) ->
+      expected = [
+        scope: 2
+        error: 'Second scope failed'
+      ,
+        scope: 1
+        data: [65432, 'foo bar baz']
+      ]
+      errOut.on 'ip', (ip) ->
+        return unless ip.type is 'data'
+        expect = expected.shift()
+        chai.expect(ip.scope).to.equal expect.scope
+        chai.expect(ip.data).to.be.an 'error'
+        chai.expect(ip.data.message).to.eql expect.error
+        return if expected.length
+        done()
+      out.on 'ip', (ip) ->
+        return unless ip.type is 'data'
+        expect = expected.shift()
+        chai.expect(ip.scope).to.equal expect.scope
+        chai.expect(ip.data).to.eql expect.data
+        return if expected.length
+        done()
+      ins[0].send new noflo.IP 'data', 65432,
+        scope: 1
+      ins[1].send new noflo.IP 'data', 123,
+        scope: 2
+      errIn.send new noflo.IP 'data', new Error('Second scope failed'),
+        scope: 2
+      ins[1].send new noflo.IP 'data', 'foo bar baz',
+        scope: 1

--- a/spec/Collate.coffee
+++ b/spec/Collate.coffee
@@ -97,7 +97,7 @@ describe 'Collate component', ->
       out.on 'endgroup', (group) ->
         return if group is null
         received.push "> #{group}"
-      out.on 'disconnect', ->
+        return unless received.length is expected.length
         chai.expect(received).to.eql expected
         done()
 

--- a/spec/Collate.coffee
+++ b/spec/Collate.coffee
@@ -32,7 +32,6 @@ describe 'Collate component', ->
 
   describe 'Collating a bank statement', ->
     it 'should return the data in the correct order', (done) ->
-      @timeout 4000
       original = [
         'branch,account,date,amount,DEP/WD'
         '1,3,1992/3/16,9.26,WD'
@@ -87,8 +86,8 @@ describe 'Collate component', ->
       received = []
       groups = []
       out.on 'begingroup', (group) ->
-        return if group is null
         groups.push group
+        return if group is null
         received.push "< #{group}"
       out.on 'data', (data) ->
         values = []
@@ -96,9 +95,10 @@ describe 'Collate component', ->
           values.push val
         received.push values.join ','
       out.on 'endgroup', (group) ->
+        groups.pop()
         return if group is null
         received.push "> #{group}"
-        return unless received.length is expected.length
+      out.on 'disconnect', ->
         chai.expect(received).to.eql expected
         done()
 

--- a/spec/Collate.coffee
+++ b/spec/Collate.coffee
@@ -32,6 +32,7 @@ describe 'Collate component', ->
 
   describe 'Collating a bank statement', ->
     it 'should return the data in the correct order', (done) ->
+      @timeout 4000
       original = [
         'branch,account,date,amount,DEP/WD'
         '1,3,1992/3/16,9.26,WD'

--- a/spec/Collate.coffee
+++ b/spec/Collate.coffee
@@ -115,6 +115,7 @@ describe 'Collate component', ->
       c.inPorts.in.attach inSock for inSock in ins
       inport.beginGroup null for inport in ins
 
+      hasNotSent = ins.slice 0
       for entry,index in original
         # Parse comma-separated
         entryData = entry.split ','
@@ -125,13 +126,19 @@ describe 'Collate component', ->
 
         # Send to a random input port
         randomConnection = Math.floor Math.random() * ins.length
+
+        # Ensure each connection sends something
+        if original.length - index is hasNotSent.length
+          randomConnection = ins.indexOf hasNotSent[0]
+        if hasNotSent.indexOf(ins[randomConnection]) isnt -1
+          hasNotSent.splice(hasNotSent.indexOf(ins[randomConnection]), 1)
+
         ins[randomConnection].send entryObj
 
         # Once we're close to the end we end stream on one of the inputs
         if index is original.length - 3
-          disconnecting = ins.pop()
+          [disconnecting] = ins.splice(randomConnection, 1)
           disconnecting.endGroup()
-
       # Finally disconnect all
       inport.endGroup() for inport in ins
 

--- a/spec/Race.coffee
+++ b/spec/Race.coffee
@@ -1,0 +1,142 @@
+noflo = require 'noflo'
+
+unless noflo.isBrowser()
+  chai = require 'chai'
+  path = require 'path'
+  baseDir = path.resolve __dirname, '../'
+else
+  baseDir = 'noflo-flow'
+
+describe 'Race component', ->
+  c = null
+  ins = []
+  errIn = null
+  out = null
+  errOut = null
+
+  before (done) ->
+    @timeout 4000
+    loader = new noflo.ComponentLoader baseDir
+    loader.load 'flow/Race', (err, instance) ->
+      return done err if err
+      c = instance
+      ins.push noflo.internalSocket.createSocket()
+      ins.push noflo.internalSocket.createSocket()
+      ins.push noflo.internalSocket.createSocket()
+      ins.push noflo.internalSocket.createSocket()
+      ins.push noflo.internalSocket.createSocket()
+      errIn = noflo.internalSocket.createSocket()
+      instance.inPorts.error.attach errIn
+      done()
+  beforeEach ->
+    out = noflo.internalSocket.createSocket()
+    c.outPorts.out.attach out
+    errOut = noflo.internalSocket.createSocket()
+    c.outPorts.error.attach errOut
+  afterEach ->
+    c.outPorts.out.detach out
+    out = null
+    c.outPorts.error.detach errOut
+    errOut = null
+  describe 'receiving results for two inbound connections', ->
+    before ->
+      c.inPorts.in.attach ins[0]
+      c.inPorts.in.attach ins[1]
+    after (done) ->
+      c.inPorts.in.detach ins[1]
+      c.inPorts.in.detach ins[0]
+      c.shutdown done
+    it 'should send the first result out', (done) ->
+      errOut.on 'data', done
+      out.on 'data', (data) ->
+        chai.expect(data).to.eql 123
+        done()
+      ins[1].send 123
+      ins[0].send 'hello world'
+    it 'should send results by scope', (done) ->
+      expected = [
+        scope: 1
+        data: 5542
+      ,
+        scope: 2
+        data: 123
+      ]
+      errOut.on 'data', done
+      out.on 'ip', (ip) ->
+        return unless ip.type is 'data'
+        expect = expected.shift()
+        chai.expect(ip.scope).to.equal expect.scope
+        chai.expect(ip.data).to.eql expect.data
+        return if expected.length
+        done()
+      ins[0].send new noflo.IP 'data', 5542,
+        scope: 1
+      ins[1].send new noflo.IP 'data', 123,
+        scope: 2
+      ins[0].send new noflo.IP 'data', 'hello world',
+        scope: 2
+      ins[1].send new noflo.IP 'data', 'foo bar',
+        scope: 1
+  describe 'receiving result and error for two inbound connections', ->
+    before ->
+      c.inPorts.in.attach ins[0]
+      c.inPorts.in.attach ins[1]
+    after (done) ->
+      c.inPorts.in.detach ins[1]
+      c.inPorts.in.detach ins[0]
+      c.shutdown done
+    it 'should send the error out and no results', (done) ->
+      errOut.on 'data', (err) ->
+        chai.expect(err).to.be.an 'error'
+        chai.expect(err.message).to.equal 'Error on first'
+        done()
+      out.on 'data', (data) ->
+        done new Error 'Unexpected data received'
+      errIn.send new Error "Error on first"
+      ins[1].send 123
+    it 'should send the error out and no results', (done) ->
+      errOut.on 'ip', (ip) ->
+        return unless ip.type is 'data'
+        chai.expect(ip.data).to.be.an 'error'
+        chai.expect(ip.data.message).to.equal 'Error on scope'
+        chai.expect(ip.scope).to.equal 0
+        done()
+      out.on 'data', (data) ->
+        done new Error 'Unexpected data received'
+      errIn.send new noflo.IP 'data', new Error('Error on scope'),
+        scope: 0
+      ins[1].send new noflo.IP 'data', 123,
+        scope: 0
+      ins[1].send new noflo.IP 'data', 456,
+        scope: 0
+    it 'should send results by scope', (done) ->
+      expected = [
+        scope: 2
+        error: 'Second scope failed'
+      ,
+        scope: 1
+        data: 65432
+      ]
+      errOut.on 'ip', (ip) ->
+        return unless ip.type is 'data'
+        expect = expected.shift()
+        chai.expect(ip.scope).to.equal expect.scope
+        chai.expect(ip.data).to.be.an 'error'
+        chai.expect(ip.data.message).to.eql expect.error
+        return if expected.length
+        done()
+      out.on 'ip', (ip) ->
+        return unless ip.type is 'data'
+        expect = expected.shift()
+        chai.expect(ip.scope).to.equal expect.scope
+        chai.expect(ip.data).to.eql expect.data
+        return if expected.length
+        done()
+      errIn.send new noflo.IP 'data', new Error('Second scope failed'),
+        scope: 2
+      ins[0].send new noflo.IP 'data', 65432,
+        scope: 1
+      ins[1].send new noflo.IP 'data', 123,
+        scope: 2
+      ins[1].send new noflo.IP 'data', 'foo bar baz',
+        scope: 1

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -23,6 +23,7 @@
       mocha.setup('bdd');
     </script>
     <script src="./Accept.js"></script>
+    <script src="./All.js"></script>
     <script src="./CleanDisconnect.js"></script>
     <script src="./CleanSplit.js"></script>
     <script src="./Collate.js"></script>

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -35,6 +35,7 @@
     <script src="./Fork.js"></script>
     <script src="./Gate.js"></script>
     <script src="./HasGroup.js"></script>
+    <script src="./Race.js"></script>
     <script src="./Reorder.js"></script>
     <script src="./ReverseSplit.js"></script>
     <script src="./Stop.js"></script>


### PR DESCRIPTION
These components are designed to be useful for combining results from multiple asynchronous processes into a single data structure.

The basic idea is that you can connect multiple components to the `IN` port of these components, and their errors to the `ERROR` inport.

Once there is a result received for each connected inport index with the same scope, the execution is considered "resolved" and results sent out. Further results in same scope have no effect.

If there is an error sent with the scope, the execution is considered "rejected" and the error sent out.  Further results in same scope have no effect.

Example:

```
# The happy path
'package.json' -> IN ReadPackage(filesystem/ReadFile) OUT -> IN[0] Collect(flow/All)
'README.md' -> IN ReadReadme(filesystem/ReadFile) OUT -> IN[1] Collect
# Error handling
ReadPackage ERROR -> ERROR Collect
ReadReadme ERROR -> ERROR Collect
```

The result of the above is either an array containing the contents of the `package.json` in `0` and the README in `1`, or an error if either fails.

`flow/Race` works the same way, except that only the first component to send a result is used.

For convenience, we should also have a component for generating unique execution contexts, and for getting back to `null` scope.

